### PR TITLE
Add issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -8,11 +8,14 @@ body:
     attributes:
       value: |
         # Welcome 👋
+
         Thanks for using conda-store and taking some time to contribute to this project.
+
         Please fill out each section below. This info allows maintainers to diagnose (and fix!) your issue as
         quickly as possible.
         Before submitting a bug, please make sure the issue hasn't been already addressed by searching through
         the past issues in this repository.
+
   - type: textarea
     attributes:
       label: Describe the bug
@@ -47,6 +50,7 @@ body:
       label: Output
       description: |
         Provide the output of the steps above, including screenshots and any tracebacks/logs.
+
         Please also ensure that the "How to reproduce the problem?" section contains matching
         instructions for reproducing this.
     validations:
@@ -69,6 +73,7 @@ body:
       label: Anything else?
       description: |
         Links? References? Anything that will give us more context about the issue you are encountering!
+
         Tip: You can attach images or log files by clicking this area to highlight it and then dragging files in.
     validations:
       required: false

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,21 +1,18 @@
 name: "Bug report 🐛"
-description: "Create a report to help us reproduce and correct the bug"
+description: "Create a report to help us fix something that is currently broken."
 title: "[BUG] - <title>"
-#labels: [] //TODO: Add labels once the repo has them
+labels: ["type: bug 🐛"]
 
 body:
   - type: markdown
     attributes:
       value: |
         # Welcome 👋
-
-        Thanks for using the JupyterLab Conda Store extension and taking some time to contribute to this project.
-
+        Thanks for using conda-store and taking some time to contribute to this project.
         Please fill out each section below. This info allows maintainers to diagnose (and fix!) your issue as
         quickly as possible.
         Before submitting a bug, please make sure the issue hasn't been already addressed by searching through
         the past issues in this repository.
-
   - type: textarea
     attributes:
       label: Describe the bug
@@ -50,7 +47,6 @@ body:
       label: Output
       description: |
         Provide the output of the steps above, including screenshots and any tracebacks/logs.
-
         Please also ensure that the "How to reproduce the problem?" section contains matching
         instructions for reproducing this.
     validations:
@@ -73,7 +69,6 @@ body:
       label: Anything else?
       description: |
         Links? References? Anything that will give us more context about the issue you are encountering!
-
         Tip: You can attach images or log files by clicking this area to highlight it and then dragging files in.
     validations:
       required: false

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,84 @@
+name: "Bug report 🐛"
+description: "Create a report to help us reproduce and correct the bug"
+title: "[BUG] - <title>"
+#labels: [] //TODO: Add labels once the repo has them
+
+body:
+  - type: markdown
+    attributes:
+      value: |
+        # Welcome 👋
+
+        Thanks for using the JupyterLab Conda Store extension and taking some time to contribute to this project.
+
+        Please fill out each section below. This info allows maintainers to diagnose (and fix!) your issue as
+        quickly as possible.
+        Before submitting a bug, please make sure the issue hasn't been already addressed by searching through
+        the past issues in this repository.
+
+  - type: textarea
+    attributes:
+      label: Describe the bug
+      description: |
+        A clear and concise description of what the bug is.
+        We suggest using bullets (indicated by * or -).
+      placeholder: Be as precise as you can.
+    validations:
+      required: true
+
+  - type: textarea
+    attributes:
+      label: Expected behavior
+      description: |
+        A clear and concise description of what you expected to happen.
+        We suggest using bullets (indicated by * or -).
+    validations:
+      required: true
+
+  - type: textarea
+    attributes:
+      label: How to Reproduce the problem?
+      description: |
+        Please provide a minimal code example to reproduce the error.
+        Be as succinct as possible, and provide detailed step by step guidelines to reproduce the bug (using numbered items).
+        If you have created a GitHub gist, you can paste the link in this box instead.
+    validations:
+      required: true
+
+  - type: textarea
+    attributes:
+      label: Output
+      description: |
+        Provide the output of the steps above, including screenshots and any tracebacks/logs.
+
+        Please also ensure that the "How to reproduce the problem?" section contains matching
+        instructions for reproducing this.
+    validations:
+      required: false
+
+  - type: textarea
+    attributes:
+      label: Versions and dependencies used.
+      description: |
+        Describe your environment:
+        - Conda version (use `conda --version`)
+        - Operating system
+        - Node version
+        - Dependencies installed and their version
+    validations:
+      required: false
+
+  - type: textarea
+    attributes:
+      label: Anything else?
+      description: |
+        Links? References? Anything that will give us more context about the issue you are encountering!
+
+        Tip: You can attach images or log files by clicking this area to highlight it and then dragging files in.
+    validations:
+      required: false
+
+  - type: markdown
+    attributes:
+      value: >
+        Thanks for contributing 🎉!

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: conda-store-ui documentation
+    url: https://conda-incubator.github.io/conda-store-ui/
+    about: Check out the conda-store documentation
+  - name: jupyterlab-conda-store issue tracker
+    about: Did you find a bug or want to make a suggestion? Open an issue on our tracker.
+    url: https://https://github.com/conda-incubator/jupyterlab-conda-store/issues/new/choose

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,15 +1,14 @@
 name: "Feature request"
 description: "Create a feature request to help us improve"
 title: "[ENH] - <title>"
-#labels: [] //TODO: Add labels once the repo has them
+labels: ["type: enhancement 💅"]
 
 body:
   - type: markdown
     attributes:
       value: |
         # Welcome 👋
-
-        Thanks for using the JupyterLab Conda Store extension and taking some time to contribute to this project.
+        Thanks for using conda-store and taking some time to contribute to this project.
   - type: textarea
     attributes:
       label: Feature description

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,39 @@
+name: "Feature request"
+description: "Create a feature request to help us improve"
+title: "[ENH] - <title>"
+#labels: [] //TODO: Add labels once the repo has them
+
+body:
+  - type: markdown
+    attributes:
+      value: |
+        # Welcome 👋
+
+        Thanks for using the JupyterLab Conda Store extension and taking some time to contribute to this project.
+  - type: textarea
+    attributes:
+      label: Feature description
+      description: |
+        Describe what you are proposing. Provide as much context as possible and link to related issues and/or pull requests.
+        This section should contain "what" you are proposing.
+        Are you having any problems? Briefly describe what your painpoints are. For example: "I'm always frustrated when ..."
+    validations:
+      required: true
+
+  - type: textarea
+    attributes:
+      label: Value and/or benefit
+      description: |
+        What is the value in adding this feature, and who will benefit from it? Include any information that could help us prioritize the issue.
+        This section should contain "why" this issue should be resolved.
+    validations:
+      required: true
+
+  - type: textarea
+    attributes:
+      label: Anything else?
+      description: |
+        Links? References? Anything that will give us more context about the issue you are encountering!
+        Tip: You can attach images or log files by clicking this area to highlight it and then dragging files in.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -8,6 +8,7 @@ body:
     attributes:
       value: |
         # Welcome 👋
+
         Thanks for using conda-store and taking some time to contribute to this project.
   - type: textarea
     attributes:

--- a/.github/ISSUE_TEMPLATE/general_issue.yml
+++ b/.github/ISSUE_TEMPLATE/general_issue.yml
@@ -8,11 +8,14 @@ body:
     attributes:
       value: |
         # Welcome 👋
+
         Thanks for using conda-store and taking some time to contribute to this project.
+
         Please fill out each section below. This info allows maintainers to diagnose (and fix!) your issue as
         quickly as possible.
         Before submitting a bug, please make sure the issue hasn't been already addressed by searching through
         the past issues in this repository.
+
   - type: textarea
     attributes:
       label: Context
@@ -37,6 +40,7 @@ body:
       label: Anything else?
       description: |
         Links? References? Anything that will give us more context about the issue you are encountering!
+
         Tip: You can attach images or log files by clicking this area to highlight it and then dragging files in.
     validations:
       required: false

--- a/.github/ISSUE_TEMPLATE/general_issue.yml
+++ b/.github/ISSUE_TEMPLATE/general_issue.yml
@@ -1,21 +1,18 @@
 name: "General issue 💡"
 description: "A general template for many kinds of issues."
 title: "<title>"
-#labels: [] //TODO: Add labels once the repo has them
+labels: ["type: question 🤔"]
 
 body:
   - type: markdown
     attributes:
       value: |
         # Welcome 👋
-
-        Thanks for using the JupyterLab Conda Store extension and taking some time to contribute to this project.
-
+        Thanks for using conda-store and taking some time to contribute to this project.
         Please fill out each section below. This info allows maintainers to diagnose (and fix!) your issue as
         quickly as possible.
         Before submitting a bug, please make sure the issue hasn't been already addressed by searching through
         the past issues in this repository.
-
   - type: textarea
     attributes:
       label: Context
@@ -40,7 +37,6 @@ body:
       label: Anything else?
       description: |
         Links? References? Anything that will give us more context about the issue you are encountering!
-
         Tip: You can attach images or log files by clicking this area to highlight it and then dragging files in.
     validations:
       required: false

--- a/.github/ISSUE_TEMPLATE/general_issue.yml
+++ b/.github/ISSUE_TEMPLATE/general_issue.yml
@@ -1,0 +1,46 @@
+name: "General issue 💡"
+description: "A general template for many kinds of issues."
+title: "<title>"
+#labels: [] //TODO: Add labels once the repo has them
+
+body:
+  - type: markdown
+    attributes:
+      value: |
+        # Welcome 👋
+
+        Thanks for using the JupyterLab Conda Store extension and taking some time to contribute to this project.
+
+        Please fill out each section below. This info allows maintainers to diagnose (and fix!) your issue as
+        quickly as possible.
+        Before submitting a bug, please make sure the issue hasn't been already addressed by searching through
+        the past issues in this repository.
+
+  - type: textarea
+    attributes:
+      label: Context
+      description: |
+        Describe what you are proposing. Provide as much context as possible and link to related issues and/or pull requests.
+        This section should contain "what" you are proposing.
+        Are you having any problems? Briefly describe what your pain points are.
+    validations:
+      required: true
+
+  - type: textarea
+    attributes:
+      label: Value and/or benefit
+      description: |
+        What is the value of adding this feature, and who will benefit from it? Include any information that could help us prioritize the issue.
+        This section should contain "why" this issue should be resolved.
+    validations:
+      required: true
+
+  - type: textarea
+    attributes:
+      label: Anything else?
+      description: |
+        Links? References? Anything that will give us more context about the issue you are encountering!
+
+        Tip: You can attach images or log files by clicking this area to highlight it and then dragging files in.
+    validations:
+      required: false

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,20 @@
+Fixes # .
+
+## Description
+<!-- What is the purpose of this pull request? -->
+
+This pull request:
+
+- a
+- b
+- c
+
+## Questions
+<!-- Any questions for reviewers of this pull request? -->
+
+No.
+
+## Other
+<!-- Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes. -->
+
+No.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,4 +1,6 @@
 Fixes # .
+<!-- Reference the issue corresponding to this PR. If an issues does not exist, consider opening one or writing a detailed descrition for what this PR changes and it's value in the following sections. -->
+<!-- GitHub Docs on Keywords: https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests -->
 
 ## Description
 <!-- What is the purpose of this pull request? -->
@@ -9,12 +11,12 @@ This pull request:
 - b
 - c
 
-## Questions
-<!-- Any questions for reviewers of this pull request? -->
+## Pull request checklist
+<!-- Quick checklist to ensure high-quality Pull Request. -->
 
-No.
+- [ ] Did you test this change locally?
+- [ ] Did you update the documentation (if required)?
+- [ ] Did you add/update relevant tests for this change (if required)?
 
-## Other
-<!-- Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes. -->
-
-No.
+## Additional information
+<!-- Do you have any other information about this pull request? This may include screenshots, references, and/or implementation notes. -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,8 +1,10 @@
 Fixes # .
-<!-- Reference the issue corresponding to this PR. If an issues does not exist, consider opening one or writing a detailed descrition for what this PR changes and it's value in the following sections. -->
+
+<!-- Reference the issue corresponding to this PR. If an issues does not exist, consider opening one or writing a detailed description for what this PR changes and it's value in the following sections. -->
 <!-- GitHub Docs on Keywords: https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests -->
 
 ## Description
+
 <!-- What is the purpose of this pull request? -->
 
 This pull request:
@@ -12,6 +14,7 @@ This pull request:
 - c
 
 ## Pull request checklist
+
 <!-- Quick checklist to ensure high-quality Pull Request. -->
 
 - [ ] Did you test this change locally?
@@ -19,4 +22,5 @@ This pull request:
 - [ ] Did you add/update relevant tests for this change (if required)?
 
 ## Additional information
+
 <!-- Do you have any other information about this pull request? This may include screenshots, references, and/or implementation notes. -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -15,7 +15,7 @@ This pull request:
 <!-- Quick checklist to ensure high-quality Pull Request. -->
 
 - [ ] Did you test this change locally?
-- [ ] Did you update the documentation (if required)?
+- [ ] Did you update the documentaion (if required)?
 - [ ] Did you add/update relevant tests for this change (if required)?
 
 ## Additional information


### PR DESCRIPTION
This PR is part of https://github.com/conda-incubator/jupyterlab-conda-store/issues/13

This PR,

- [x] Adds an issue template for bug reports
- [x] Adds an issue template for feature requests
- [x] Adds an issue template for general issues

## Notes

- Given that we don't have labels in the repo yet there's some `TODOs` that we may need to resolve before merging this PR.
- I don't have powers in the repo to create the labels so I'll wait either for powers to do them or for someone to create them.