### PR TITLE
add trusted publishers method

### DIFF
--- a/.github/workflows/build_and_deploy_release.yml
+++ b/.github/workflows/build_and_deploy_release.yml
@@ -5,8 +5,10 @@ on:
   push:
     tags:        
       - 'v*'          
-jobs:
+permissions:
+  id-token: write
 
+jobs:
   call-build:
     uses: conda-incubator/jupyterlab-conda-store/.github/workflows/build.yml@main
 
@@ -25,14 +27,5 @@ jobs:
         name: extension-artifacts
         path: dist/
       
-    - name: Upload to pypi
-      run: |
-        set -eux
-        pip install twine
-        twine upload -r pypi dist/*
-      env:
-        TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
-        TWINE_PASSWORD:  ${{ secrets.PYPI_PASSWORD }}
-       
-      
-        
+    - name: Upload to PyPI
+      uses: pypa/gh-action-pypi-publish@release/v1        

--- a/.github/workflows/build_and_deploy_release.yml
+++ b/.github/workflows/build_and_deploy_release.yml
@@ -5,9 +5,6 @@ on:
   push:
     tags:        
       - 'v*'          
-permissions:
-  id-token: write
-
 jobs:
   call-build:
     uses: conda-incubator/jupyterlab-conda-store/.github/workflows/build.yml@main
@@ -16,6 +13,8 @@ jobs:
     runs-on: ubuntu-latest
     if: always() # Runs despite playwright tests failing
     needs: call-build
+    permissions:
+      id-token: write
 
     steps:
     - name: Checkout


### PR DESCRIPTION
Fixes #13 
Fixes https://github.com/conda-incubator/conda-store/issues/519

<!-- Reference the issue corresponding to this PR. If an issues does not exist, consider opening one or writing a detailed description for what this PR changes and it's value in the following sections. -->
<!-- GitHub Docs on Keywords: https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests -->

## Description

This PR updates the GitHub actions workflow to use the new trusted publishing method to distribute its package. 

This pull request:

- a
- b
- c

## Pull request checklist

<!-- Quick checklist to ensure high-quality Pull Request. -->

- [ ] Did you test this change locally?
- [ ] Did you update the documentaion (if required)?
- [ ] Did you add/update relevant tests for this change (if required)?

## Additional information

<!-- Do you have any other information about this pull request? This may include screenshots, references, and/or implementation notes. -->
