### PR TITLE
Fix broken link to conda-store logo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # jupyterlab-conda-store
 
 <div align="center">
-  <img src="https://raw.githubusercontent.com/conda-incubator/conda-store/main/docs/_static/images/conda-store-logo-vertical-lockup.svg" alt="conda-store logo" width="30%">
+  <img src="https://raw.githubusercontent.com/conda-incubator/conda-store/main/docusaurus-docs/community/assets/logos/conda-store-logo-vertical-lockup.svg" alt="conda-store logo" width="30%">
 </div>
 
 ---


### PR DESCRIPTION
Fixes the link to conda-store logo #31

Preview: https://github.com/isumitjha/jupyterlab-conda-store/tree/logo-broken-readme

<img width="883" alt="Screenshot 2023-12-16 at 11 51 01 am" src="https://github.com/conda-incubator/jupyterlab-conda-store/assets/30199572/434d14ad-35ef-43b9-9be7-3403ef78f8d0">

<!-- Reference the issue corresponding to this PR. If an issues does not exist, consider opening one or writing a detailed description for what this PR changes and it's value in the following sections. -->
<!-- GitHub Docs on Keywords: https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests -->

## Description

<!-- What is the purpose of this pull request? -->

This pull request:

- Fixes the link to conda-store logo in the README

## Pull request checklist

<!-- Quick checklist to ensure high-quality Pull Request. -->

- [ ] Did you test this change locally?
- [ ] Did you update the documentation (if required)?
- [ ] Did you add/update relevant tests for this change (if required)?

## Additional information

<!-- Do you have any other information about this pull request? This may include screenshots, references, and/or implementation notes. -->
