### PR TITLE
MAINT - Update dev setup instructions

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -6,3 +6,7 @@ tests
 
 **/__tests__
 ui-tests
+
+# Ignore files for NPM and YARN
+package-lock.json
+yarn.lock

--- a/.prettierignore
+++ b/.prettierignore
@@ -3,3 +3,7 @@ node_modules
 **/lib
 **/package.json
 jupyterlab_conda_store
+
+# Ignore files for NPM and YARN
+package-lock.json
+yarn.lock

--- a/README.md
+++ b/README.md
@@ -64,46 +64,51 @@ pip uninstall jupyterlab-conda-store
     cd jupyterlab-conda-store
    ```
 
-3. Optional but recommended - Create and activate a development environment with conda:
+3. Create a new conda environment:
 
    ```bash
-   # Create environment named `jupyterlab-conda-store`
-   conda create -n jupyterlab-conda-store
+   conda env create -f environment.yml
+
+   # activate the environment
    conda activate jupyterlab-conda-store
    ```
 
-4. Install JupyterLab and NodeJS **if not installed**:
+4. Install the package in development mode:
 
    ```bash
-   # Install node and jupyterlab from conda-forge
-   conda install -c conda-forge 'nodejs>16' 'jupyterlab>=4'
+   python -m pip install -e .
    ```
 
-5. Install the package in development mode:
+5. Now you'll need to link the development version of the extension to JupyterLab and rebuild the Typescript source:
 
    ```bash
-   pip install -e .
-   ```
-
-6. Now you'll need to link the development version of the extension to JupyterLab and rebuild the Typescript source:
-
-   ```bash
+   # Install the extension dependencies
+   jlpm install
    # Link your development version of the extension with JupyterLab
    jupyter labextension develop . --overwrite
    ```
 
-7. On the first installation, or after making some changes, to visualize them in your local JupyterLab re-run the following command:
+6. On the first installation, or after making some changes, to visualize them in your local JupyterLab re-run the following command:
 
    ```bash
    # Rebuild extension Typescript source after making changes
-   jlpm build
+   jlpm run build
    ```
 
-8. Run JupyterLab and check that the installation worked:
+7. Run JupyterLab and check that the installation worked:
+
+   ```bash
+   # Run JupyterLab
+   jupyter lab
+   ```
+
+> [!TIP]
+> At times you might need to clean your local repo with the command `npm run clean:slate`. This will clean the repository, and re-install and rebuild.
+
+To lint files as you work on contributions, you can run:
 
 ```bash
-# Run JupyterLab
-jupyter lab
+jlpm run lint:check
 ```
 
 ### Uninstalling the development version

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -18,7 +18,7 @@ All the Python packaging instructions in the `pyproject.toml` file to wrap your 
 > [!IMPORTANT]
 > There is no need to update the version in `pyproject.toml` as it is automatically updated by `hatch` when generating the package.
 
-3. Optional - if there is a newer release of `conda-store-ui`, update the `conda-store-ui` dependency in the package.json file.
+3. Optional - if there is a newer release of `conda-store-ui`, update the `conda-store-ui` dependency in the `package.json` file.
 
    ```bash
    yarn upgrade @conda-store/conda-store-ui@<version>
@@ -27,7 +27,7 @@ All the Python packaging instructions in the `pyproject.toml` file to wrap your 
 4. To create a Python source package (`.tar.gz`) and the binary package (`.whl`) in the `dist/` directory, do:
 
    ```bash
-   python -m build
+   hatch build
    ```
 
 `python setup.py sdist bdist_wheel` is deprecated and will not work for this package.

--- a/environment.yaml
+++ b/environment.yaml
@@ -1,0 +1,8 @@
+name: jupyterlab-conda-store
+channels:
+  - conda-forge
+  - nodefaults
+dependencies:
+  - python>=3.9
+  - nodejs=20
+  - jupyterlab>=4

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,7 @@ test = [
     "pytest-cov",
     "pytest-tornasync"
 ]
+dev = ["hatch"]
 
 [project.urls]
 Homepage = "https://github.com/conda-incubator/jupyterlab-conda-store"


### PR DESCRIPTION
## Description

As I had to set up a new dev environment due to changing computers this was a good opportunity to go over the dev install instructions again. This PR adds a few improvements:

- Add an `environment.yaml` file and updated instructions
- Update `RELEASE` instructions to use `hatch` for build
- Ignore `lock` files from listing (there have been some issues with this in the past)

## Pull request checklist

<!-- Quick checklist to ensure high-quality Pull Request. -->

- [x] Did you test this change locally?
- [x] Did you update the documentation (if required)?
- [ ] Did you add/update relevant tests for this change (if required)?

## Additional information

<!-- Do you have any other information about this pull request? This may include screenshots, references, and/or implementation notes. -->

## How to test

<!-- Please add any relevant details to test this functionality even if you added automated tests -->
