### PR TITLE
MAINT - Bump GH actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+---
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    labels:
+      - "area: CI 👷🏽‍♀️"
+      - "area: dependencies 📦"
+    # ensure we have a nicely formatted commit message
+    prefix: "MAINT - "

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -53,7 +53,7 @@ jobs:
           python -m build
 
       - name: 'Upload extension packages 📤'
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: extension-artifacts
           path: dist/
@@ -70,11 +70,11 @@ jobs:
       - name: 'Install Python 🐍'
         uses: actions/setup-python@v5
         with:
-          python-version: '3.9'
+          python-version: '3.12'
           architecture: 'x64'
 
-      - name: 'Download extension packages 📤'
-        uses: actions/download-artifact@v3
+      - name: 'Download extension packages 📥'
+        uses: actions/download-artifact@v4
         with:
           name: extension-artifacts
 
@@ -102,44 +102,44 @@ jobs:
       - name: 'Checkout repository 🛎'
         uses: actions/checkout@v4
 
-      - name: 'Base Setup'
+      - name: 'Base Setup 🛠'
         uses: jupyterlab/maintainer-tools/.github/actions/base-setup@v1
 
       - name: 'Download extension packages 📤'
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: extension-artifacts
 
-      - name: 'Install the extension'
+      - name: 'Install the extension 📦'
         run: |
           set -eux
           python -m pip install "jupyterlab>4" jupyterlab_conda_store*.whl
 
-      - name: 'Install dependencies'
+      - name: 'Install dependencies 📦'
         working-directory: ui-tests
         env:
           PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: 1
         run: jlpm install
 
-      - name: 'Set up browser cache'
+      - name: 'Set up browser cache 🛠️'
         uses: actions/cache@v4
         with:
           path: |
             ${{ github.workspace }}/pw-browsers
           key: ${{ runner.os }}-${{ hashFiles('ui-tests/yarn.lock') }}
 
-      - name: 'Install browser'
+      - name: 'Install browser 🌐'
         run: jlpm playwright install chromium
         working-directory: ui-tests
 
-      - name: Execute integration tests
+      - name: 'Execute integration tests 🧪'
         working-directory: ui-tests
         run: |
           jlpm playwright test
 
-      - name: Upload Playwright Test report
+      - name: 'Upload Playwright Test report 📤'
         if: always()
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: jupyterlab_conda_store-playwright-tests
           path: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -61,7 +61,7 @@ jobs:
           twine check dist/*
 
       - name: 'Upload extension packages 📤'
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: jupyterlab-extension-package
           path: dist/
@@ -79,7 +79,7 @@ jobs:
 
     steps:
       - name: 'Download build artefacts 📥'
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: jupyterlab-extension-package
           path: dist
@@ -102,7 +102,7 @@ jobs:
 
     steps:
       - name: 'Download build artefacts 📥'
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: jupyterlab-extension-package
           path: dist


### PR DESCRIPTION
## Description

The CI seems to be failing due to the use of deprecated actions (see https://github.com/conda-incubator/jupyterlab-conda-store/actions/runs/11464702869/job/31901668859?pr=63)

This PR:
- Bumps the various actions in our workflows
- Adds a dependabot config file so the updates are automatic moving forward
- Also noticed we never added a note about https://github.com/conda-incubator/jupyterlab-conda-store/issues/41

## Pull request checklist

<!-- Quick checklist to ensure high-quality Pull Request. -->

- [x] Did you test this change locally?
- [x] Did you update the documentation (if required)?
- [ ] Did you add/update relevant tests for this change (if required)?

## Additional information

<!-- Do you have any other information about this pull request? This may include screenshots, references, and/or implementation notes. -->

## How to test

<!-- Please add any relevant details to test this functionality even if you added automated tests -->

Fixes https://github.com/conda-incubator/jupyterlab-conda-store/issues/41