### PR TITLE
Bump conda-store-ui version

### DIFF
--- a/.github/ISSUE_TEMPLATE/new_release.md
+++ b/.github/ISSUE_TEMPLATE/new_release.md
@@ -28,7 +28,7 @@ Release captain responsible - <@gh_username>
 - [ ] [Optional] Update the `conda-store-ui` version used in the extension:
 
   ```bash
-  yarn upgrade @conda-store/conda-store-ui@<version>
+  jlpm up @conda-store/conda-store-ui@<version>
   ```
 
 - [ ] Update the [CHANGELOG.md](./CHANGELOG.md) file with the new version, release date, and relevant changes [^github-activity].

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -21,7 +21,7 @@ All the Python packaging instructions in the `pyproject.toml` file to wrap your 
 3. Optional - if there is a newer release of `conda-store-ui`, update the `conda-store-ui` dependency in the `package.json` file.
 
    ```bash
-   yarn upgrade @conda-store/conda-store-ui@<version>
+   jlpm up @conda-store/conda-store-ui@<version>
    ```
 
 4. To create a Python source package (`.tar.gz`) and the binary package (`.whl`) in the `dist/` directory, do:

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "watch:labextension": "jupyter labextension watch ."
   },
   "dependencies": {
-    "@conda-store/conda-store-ui": "2024.10.1",
+    "@conda-store/conda-store-ui": "2024.11.1",
     "@jupyterlab/application": "^4.0.9",
     "@jupyterlab/apputils": "^4.1.2",
     "@jupyterlab/mainmenu": "^4.0.9",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1658,9 +1658,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@conda-store/conda-store-ui@npm:2024.10.1":
-  version: 2024.10.1
-  resolution: "@conda-store/conda-store-ui@npm:2024.10.1"
+"@conda-store/conda-store-ui@npm:2024.11.1":
+  version: 2024.11.1
+  resolution: "@conda-store/conda-store-ui@npm:2024.11.1"
   dependencies:
     "@codemirror/language": ^6.2.1
     "@codemirror/legacy-modes": ^6.1.0
@@ -1691,7 +1691,7 @@ __metadata:
     redux: ^4.2.0
     semver: ^7.3.8
     yaml: ^2.1.1
-  checksum: ad1d39e1e56bd36e080c2c2c6a2084ee147367bf9fd870161840c773aa0991eae170200fb1b2f9fc93032eb6100e1747ee235b04a0bde2655717bc1b73ab25ad
+  checksum: c75da5b9495f7d3ba6385add917e567820610979b5ab3c06d56f14603e19b0199ed8a1bb69b5ced682f726c7fec551ede4b9993380ba2043a3045b4051b1be57
   languageName: node
   linkType: hard
 
@@ -8839,7 +8839,7 @@ __metadata:
   dependencies:
     "@babel/core": ^7.0.0
     "@babel/preset-env": ^7.0.0
-    "@conda-store/conda-store-ui": 2024.10.1
+    "@conda-store/conda-store-ui": 2024.11.1
     "@jupyterlab/application": ^4.0.9
     "@jupyterlab/apputils": ^4.1.2
     "@jupyterlab/builder": ^4.0.0


### PR DESCRIPTION
To bump the ui version (from a clean clone)
```
    $ conda activate jupyterlab-conda-store
    
    // update @conda-store/conda-store-ui dep in package.json
    
    $ jlpm install
```

## Pull request checklist

- [ ] Did you test this change locally?
- [x] Did you update the documentation (if required)?
- [x] Did you add/update relevant tests for this change (if required)?
